### PR TITLE
カレンダー課題提出

### DIFF
--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -1,32 +1,32 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'date'
 require 'optparse'
 opt = OptionParser.new
 month = Date.today.month
 year = Date.today.year
-opt.on('-m [val]') {|m| month = m.to_i }
-opt.on('-y [val]') {|y| year = y.to_i }
-
+opt.on('-m [val]') { |m| month = m.to_i }
+opt.on('-y [val]') { |y| year = y.to_i }
 opt.parse!(ARGV)
 
-day_start = Date.new(year,month,1)
-day_end = Date.new(year,month,-1)
-days = (day_start.day..day_end.day)
+day_start = Date.new(year, month, 1)
+day_end = Date.new(year, month, -1)
 days_to_shift = day_start.wday + 3
 
-weekdays = ["日","月","火","水","木","金","土"]
+weekdays = %w[日 月 火 水 木 金 土]
 puts "      #{month}月 #{year}"
-weekdays.each {|day| print day.ljust(2)}
-puts ""
-print "  " * days_to_shift
-(day_start..day_end).each {|date|
+weekdays.each { |day| print day.ljust(2) }
+puts ''
+print '  ' * days_to_shift
+(day_start..day_end).each do |date|
   if month == Date.today.month && date.day == Date.today.day && year == Date.today.year
     print "\e[30m\e[47m"
   else
     print "\e[0m"
   end
-  print "#{date.day.to_s.rjust(2)}" + "\e[0m "
-  puts "" if date.saturday? 
+  print "#{date.day.to_s.rjust(2)}\e[0m "
+  puts '' if date.saturday?
   print "\e[0m"
-}
-puts ""
+end
+puts ''

--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -20,8 +20,9 @@ weekdays.each { |day| print day.ljust(2) }
 puts ''
 print '   ' * days_to_shift
 (day_start..day_end).each do |date|
-  Date.today == date ? (print "\e[7m") : (print "\e[0m")
-  print "#{date.day.to_s.rjust(2)}\e[0m "
+  date_string = date.day.to_s.rjust(2)
+  date_string = "\e[7m#{date_string}\e[0m" if Date.today == date
+  print "#{date_string} "
   puts '' if date.saturday?
 end
 puts ''

--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -1,0 +1,43 @@
+#!/usr/bin/env ruby
+require 'date'
+require 'optparse'
+opt = OptionParser.new
+month = Date.today.month
+year = Date.today.year
+opt.on('-m [val]') {|m| month = m.to_i }
+opt.on('-y [val]') {|y| 
+  if y == nil
+    year = Date.today.year
+  else
+    year = y.to_i
+  end 
+}
+
+opt.parse!(ARGV)
+
+day_start = Date.new(year,month,1)
+day_end = Date.new(year,month,-1)
+days = [*day_start.day..day_end.day]
+
+days_to_shift = day_start.wday + 1
+disp_days = days
+days_to_shift.times{
+  disp_days = days.unshift("")
+}
+
+weekdays = ["日","月","火","水","木","金","土"]
+puts sprintf("      %d月 %d", month,year)
+print sprintf("%s " * weekdays.length, *weekdays)
+disp_days.each_with_index {|day,i|
+  if month == Date.today.month && day == Date.today.day
+    print "\e[31m"
+  else
+    print "\e[0m"
+  end
+  print sprintf("%2s ",day)
+  if i % 7 == 0
+    puts ""
+  end
+  print "\e[0m"
+}
+puts ""

--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -5,39 +5,28 @@ opt = OptionParser.new
 month = Date.today.month
 year = Date.today.year
 opt.on('-m [val]') {|m| month = m.to_i }
-opt.on('-y [val]') {|y| 
-  if y == nil
-    year = Date.today.year
-  else
-    year = y.to_i
-  end 
-}
+opt.on('-y [val]') {|y| year = y.to_i }
 
 opt.parse!(ARGV)
 
 day_start = Date.new(year,month,1)
 day_end = Date.new(year,month,-1)
-days = [*day_start.day..day_end.day]
-
-days_to_shift = day_start.wday + 1
-disp_days = days
-days_to_shift.times{
-  disp_days = days.unshift("")
-}
+days = (day_start.day..day_end.day)
+days_to_shift = day_start.wday + 3
 
 weekdays = ["日","月","火","水","木","金","土"]
-puts sprintf("      %d月 %d", month,year)
-print sprintf("%s " * weekdays.length, *weekdays)
-disp_days.each_with_index {|day,i|
-  if month == Date.today.month && day == Date.today.day
-    print "\e[31m"
+puts "      #{month}月 #{year}"
+weekdays.each {|day| print day.ljust(2)}
+puts ""
+print "  " * days_to_shift
+(day_start..day_end).each {|date|
+  if month == Date.today.month && date.day == Date.today.day && year == Date.today.year
+    print "\e[30m\e[47m"
   else
     print "\e[0m"
   end
-  print sprintf("%2s ",day)
-  if i % 7 == 0
-    puts ""
-  end
+  print "#{date.day.to_s.rjust(2)}" + "\e[0m "
+  puts "" if date.saturday? 
   print "\e[0m"
 }
 puts ""

--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -12,13 +12,13 @@ opt.parse!(ARGV)
 
 day_start = Date.new(year, month, 1)
 day_end = Date.new(year, month, -1)
-days_to_shift = day_start.wday + 3
+days_to_shift = day_start.wday
 
 weekdays = %w[日 月 火 水 木 金 土]
 puts "      #{month}月 #{year}"
 weekdays.each { |day| print day.ljust(2) }
 puts ''
-print '  ' * days_to_shift
+print '   ' * days_to_shift
 (day_start..day_end).each do |date|
   if month == Date.today.month && date.day == Date.today.day && year == Date.today.year
     print "\e[30m\e[47m"

--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -20,13 +20,8 @@ weekdays.each { |day| print day.ljust(2) }
 puts ''
 print '   ' * days_to_shift
 (day_start..day_end).each do |date|
-  if month == Date.today.month && date.day == Date.today.day && year == Date.today.year
-    print "\e[30m\e[47m"
-  else
-    print "\e[0m"
-  end
+  Date.today == date ? (print "\e[7m") : (print "\e[0m")
   print "#{date.day.to_s.rjust(2)}\e[0m "
   puts '' if date.saturday?
-  print "\e[0m"
 end
 puts ''


### PR DESCRIPTION
プラクティス「カレンダーのプログラム(Ruby)」の課題を提出します。

-  `-m`で月を、`-y`で年を指定できる  → ok
- ただし、`-y`のみ指定して一年分のカレンダーを表示する機能の実装は不要 → ok
- 引数を指定しない場合は、今月・今年のカレンダーが表示される → ok
- MacやWSLに入っているcalコマンドと同じ見た目になっている(OSのcalコマンドと自分のcalコマンドの両方の実行結果を載せてください)  → 別のフォームで提出します。
- 少なくとも1970年から2100年までは正しく表示される → ok